### PR TITLE
Fetch latest git changes

### DIFF
--- a/components/project-chat.tsx
+++ b/components/project-chat.tsx
@@ -1164,8 +1164,8 @@ export const ProjectChat = ({ projectId }: ProjectChatProps) => {
                 {(() => {
                   const active = tagSuggestions[tagIdx]
                   if (!active) return null
-                  const groupLabels = Array.from(new Set(tagOptionsAll.filter((o) => o.value === active.value).map((o) => o.label)))
-                  if (groupLabels.length <= 1) return null
+                const allLabels = Array.from(new Set(tagOptionsAll.map((o) => o.label)))
+                if (allLabels.length === 0) return null
                   const baseKey = (() => {
                     const inAll = tagOptionsAll.find((o) => o.value === active.value && typeof o.baseLabel === 'string')
                     return (inAll?.baseLabel || resolveCanonicalLabel(active.value, tagOptionsAll) || active.label)
@@ -1176,7 +1176,7 @@ export const ProjectChat = ({ projectId }: ProjectChatProps) => {
                     <div className=" text-xs text-foreground">
                       <div className="font-medium">#{headingLabel}:</div>
                       <div className="h-24 overflow-x-auto overflow-y-hidden grid grid-flow-col auto-cols-max grid-rows-3 content-start items-start gap-1.5 pr-2">
-                        {groupLabels.filter((l) => l !== headingLabel).map((l) => {
+                        {allLabels.filter((l) => l !== headingLabel).map((l) => {
                           const picked = chosen.includes(l)
                           return (
                             <button


### PR DESCRIPTION
## Description

Updated the synonym selection panel in the project chat to display all available synonyms fetched from the `/api/tags` endpoint, rather than just those related to the `baseLabel`. Selected synonyms are now highlighted within this comprehensive list.

## Related Issues

Closes #

## Checklist

- [ ] My code follows the code style of this project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation, if necessary.

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes, especially if this is a UI-related PR. -->

## Additional Notes

This change addresses user feedback to provide a clearer and more complete view of all possible synonym options, along with their current selection status, when interacting with hashtags in the chat input.

---
<a href="https://cursor.com/background-agent?bcId=bc-aa0ecaf9-80e5-4416-8afd-2ca83104607c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aa0ecaf9-80e5-4416-8afd-2ca83104607c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

